### PR TITLE
Set location ID on post during catch creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -227,7 +227,8 @@ app.post('/locations/:id/catch', isLoggedIn, async (req, res) => {
         const image = '/uploads/' + req.file.filename;
 
         const post = await Post.create({
-            species, image, weight, description, catchlocation, catchlocationid
+            species, image, weight, description, catchlocation, catchlocationid,
+            location: req.params.id
         });
 
         post.author.id = req.user._id;


### PR DESCRIPTION
The Post model's location field was never being populated. Now passes req.params.id as the location reference when creating a post.